### PR TITLE
Reference is displayed in card format

### DIFF
--- a/flaskapp/templates/home.html
+++ b/flaskapp/templates/home.html
@@ -43,10 +43,22 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}
-      <div class="pb-2">
-          {{ message }}
+      <div class="card">
+        <div class="card-header">
+          <ul class="nav nav-tabs card-header-tabs" id="myTab" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="raw-tab" data-bs-toggle="tab" data-bs-target="#raw" type="button" role="tab" aria-controls="raw" aria-selected="true">Raw</button>
+            </li>
+          </ul>
+        </div>
+        <div class="tab-content card-body" id="myTabContent">
+          <div class="tab-pane fade show active" id="raw" role="tabpanel" aria-labelledby="raw-tab">
+            {{message}}
+          </div>
+        </div>
       </div>
-      <div class="text-center">
+
+      <div class="text-center pt-2">
           <button class="btn btn-outline-secondary" onClick="copyToClipboard('{{message}}')">Copy reference</button>
       </div>
       {% endfor %}


### PR DESCRIPTION
The generated reference is now displayed using the Bootstrap `card` class. While not explicitly mentioned, it can be seen as work towards https://github.com/BX326/url2ref/issues/1. 
Preliminary work has also been done to support multiple tabs within the card, particularly in expectation of https://github.com/BX326/url2ref/issues/1 point 3.